### PR TITLE
feat(nav): navigation bar for mobile screens

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@styled-icons/heroicons-solid": "^10.47.0",
     "framer-motion": "^10.16.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/appcover/appcover.styles.ts
+++ b/frontend/src/components/appcover/appcover.styles.ts
@@ -5,11 +5,7 @@ export const AppcoverContainer = styled.div`
     width: 100%;
     min-height: 100%;
     display: grid;
-    grid-template-rows: 1fr 8fr;
-
-    @media only screen and (max-width: 900px) {
-        grid-template-rows: 1fr 11fr;
-    }
+    grid-template-rows: auto 1fr;
 `
 
 export const AppcoverDisplay = styled.div`

--- a/frontend/src/components/navbar/navbar.styles.ts
+++ b/frontend/src/components/navbar/navbar.styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { ArrowLeftOnRectangle, Bars3BottomRight, XCircle } from "@styled-icons/heroicons-solid"
 
 export const NavbarContainer = styled.div`
     display: flex;
@@ -26,6 +27,7 @@ export const NavbarContent = styled.div`
     @media only screen and (max-width: 900px) {
         width: 95%;
         justify-content: center;
+        padding: 0.6rem 1.5rem;
     }
 `
 
@@ -56,7 +58,7 @@ export const NavbarItems = styled.div`
 
 export const NavbarItem = styled.div<{ active?: boolean }>`
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
     cursor: pointer;
     color: ${props => props.active ? '#FF0000' : '#FFFFFF'};
@@ -71,12 +73,124 @@ export const NavbarItem = styled.div<{ active?: boolean }>`
         font-size: 1.1rem;
         color: ${props => props.active ? '#FFFFFF' : '#A0A0A0'};
     }
-
-    span:hover {
-        color: #FFF;
+    img {
+        color: red;
     }
-
     &:hover {
         color: #A0A0A0;
+        span {
+            color: #FFFFFF;
+        }
+        svg {
+            color: #FFFFFF;
+        }
     }
+
+    @media only screen and (max-width: 900px) {
+        width: 90%;
+        text-align: center;
+        justify-content: center;
+        padding: 1rem 0;
+        border-radius: 1rem;
+        background-color: ${props => props.active ? '#1C1A1B' : '#000000'};
+        box-shadow: inset 0 0 10px rgba(250, 250, 250, 0.8);
+
+        &:hover {
+            color: #FF0000;
+            background-color: #1C1A1B;
+        }
+    }
+`
+
+export const NavbarSignout = styled(ArrowLeftOnRectangle)`
+    width: 2rem;
+    height: 2rem;
+    color: #FF0000;
+    cursor: pointer;
+    transition: 0.3s ease;
+`
+
+export const NavbarMobileLayer = styled.div<{ toggled ?: boolean }>`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+
+    background-color: rgba(0, 0, 0, 0.2);
+    z-index: 999;
+    transition: all 0.3s ease-in-out;
+    display: ${props => props.toggled ? 'flex' : 'none'};
+    justify-content: center;
+    align-items: center;
+`
+
+export const NavbarMobile = styled.div<{ toggled ?: boolean }>`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 80%;
+    height: 100%;
+
+    padding: 2rem 1.5rem;
+
+    background-color: #1C1A1B;
+    box-shadow: inset 0 0 15px rgba(50, 50, 50, 0.8);
+
+    display: none;
+    flex-direction: column;
+    
+    gap: 3rem;
+    transition: all 0.3s ease-in-out;
+    transform: ${props => props.toggled ? 'translateX(0)' : 'translateX(-100%)'};
+    z-index: 1000;
+
+    @media only screen and (max-width: 900px) {
+        display: flex;
+    }
+`
+
+export const NavbarMobileItems = styled.div`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+`
+
+export const NavbarTop = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    align-items: center;
+`
+
+export const NavbarToggleOpen = styled(Bars3BottomRight)`
+    width: 2rem;
+    height: 2rem;
+    color: #FFFFFF;
+    cursor: pointer;
+    transition: 0.3s ease;
+
+    display: none;
+
+    @media only screen and (max-width: 900px) {
+        display: block;
+    }
+`
+
+export const NavbarToggleClose = styled(XCircle)`
+    width: 3rem;
+    height: 3rem;
+    color: #FFFFFF;
+    cursor: pointer;
+    transition: 0.3s ease;
+    display: none;
+
+    @media only screen and (max-width: 900px) {
+        display: block;
+    }
+`
+
+export const NavbarDesc = styled.div`
+    max-width: 90%;
+    color: #FFFFFF;
 `

--- a/frontend/src/components/navbar/navbar.tsx
+++ b/frontend/src/components/navbar/navbar.tsx
@@ -10,6 +10,13 @@ const navItems = [
     { name: 'lytics', link: '/app/analytics' },
 ]
 
+function getTimeOfDay() {
+    const time = new Date().getHours()
+    if (time >= 5 && time < 12) return "Morning"
+    if (time >= 12 && time < 18) return "Afternoon"
+    return "Evening"
+}
+
 export default function Navbar() {
 
     const [mobileToggle, setMobileToggle] = useState(false)
@@ -47,7 +54,7 @@ export default function Navbar() {
                     <NavbarToggleClose onClick={() => setMobileToggle(false)} />
                 </NavbarTop>
                 <NavbarDesc>
-                    Welcome, and a very good morning, Qreate. Ready to storm the world with your information?
+                    Good {getTimeOfDay()}, Qreate. Embark on a journey of imagination where boundaries cease to exist.
                 </NavbarDesc>
                 <NavbarMobileItems>
                     {navItems.map((item, index) => {

--- a/frontend/src/components/navbar/navbar.tsx
+++ b/frontend/src/components/navbar/navbar.tsx
@@ -1,7 +1,10 @@
-import { NavbarContainer, NavbarContent, NavbarLogo, NavbarItems, NavbarItem } from "./navbar.styles"
+import { useState } from "react"
+import { NavbarContainer, NavbarContent, NavbarLogo, NavbarItems, NavbarItem, NavbarSignout, NavbarMobile, NavbarTop, NavbarToggleOpen, NavbarToggleClose, NavbarDesc, NavbarMobileItems, NavbarMobileLayer } from "./navbar.styles"
+import { useNavigate } from "react-router-dom"
+
 
 const navItems = [
-    { name: 'Dash', link: '/app/dashboard'},
+    { name: 'Dash', link: '/app/dashboard' },
     { name: 'Brand', link: '/app/brand' },
     { name: 'Editor', link: '/app/editor' },
     { name: 'lytics', link: '/app/analytics' },
@@ -9,21 +12,58 @@ const navItems = [
 
 export default function Navbar() {
 
+    const [mobileToggle, setMobileToggle] = useState(false)
+    const navigate = useNavigate()
+
     return (
         <NavbarContainer>
             <NavbarContent>
-                <NavbarLogo>Qreateboard</NavbarLogo>
+                <NavbarTop>
+                    <NavbarLogo>Qreateboard</NavbarLogo>
+                    <NavbarToggleOpen onClick={() => setMobileToggle(true)} />
+                </NavbarTop>
                 <NavbarItems>
                     {navItems.map((item, index) => {
                         return (
-                            <NavbarItem key={index} active={window.location.pathname === item.link}>
+                            <NavbarItem 
+                                key={index} 
+                                active={window.location.pathname === item.link}
+                                onClick={() => navigate(item.link)}
+                            >
                                 Q<span>{item.name}</span>
                             </NavbarItem>
                         )
                     })}
-                    <NavbarItem>Sign-<span>Out</span></NavbarItem>
+                    <NavbarItem>Sign-<span>Out</span><NavbarSignout /></NavbarItem>
                 </NavbarItems>
             </NavbarContent>
+            <NavbarMobileLayer 
+                toggled={mobileToggle} 
+                onClick={() => setMobileToggle(false)}  
+            />
+            <NavbarMobile toggled={mobileToggle}>
+                <NavbarTop>
+                    <NavbarLogo>Qreateboard</NavbarLogo>
+                    <NavbarToggleClose onClick={() => setMobileToggle(false)} />
+                </NavbarTop>
+                <NavbarDesc>
+                    Welcome, and a very good morning, Qreate. Ready to storm the world with your information?
+                </NavbarDesc>
+                <NavbarMobileItems>
+                    {navItems.map((item, index) => {
+                        return (
+                            <NavbarItem 
+                                key={index} 
+                                active={window.location.pathname === item.link}
+                                onClick={() => navigate(item.link)}
+                            >
+                                Q<span>{item.name}</span>
+                            </NavbarItem>
+                        )
+                    })}
+                    <NavbarItem>Sign-<span>Out</span><NavbarSignout /></NavbarItem>
+                </NavbarMobileItems>
+            </NavbarMobile>
         </NavbarContainer>
     )
 


### PR DESCRIPTION
### Fixes/Implements #1 

## Description

- The mobile navigation bar is displayed over a media query of `900px`
- It can be closed, or opened upon a button click.
- The current `sign-out` model is added with an `.svg` which suits the purpose.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested