### PR TITLE
fix(frontend): patch for several found issues - 2

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,8 @@ export function AppWrapper({ children }: { children: React.ReactNode }) {
     Function to handle Log in
 
     @param token: string
-    @param userData: any
+    @param brand_name: string
+    @param brand_email: string
 
     @return void
     */

--- a/frontend/src/components/appcover/appcover.tsx
+++ b/frontend/src/components/appcover/appcover.tsx
@@ -1,7 +1,28 @@
+import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+
 import Navbar from "../navbar/navbar";
 import { AppcoverContainer, AppcoverDisplay } from "./appcover.styles";
+import Loading from "../loading/loading";
+
+import { useGlobalContext } from "../../contexts/global.context";
+
 
 export default function Appcover({ children }: { children: React.ReactNode }) {
+
+    const { isLoggedIn, isLoading, handleSignOut } = useGlobalContext()
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        if (!isLoggedIn && !isLoading) {
+            handleSignOut!()
+            navigate('/sign-in')
+        }
+    }, [isLoggedIn, isLoading])
+    
+
+    if (isLoading || !isLoggedIn) return <Loading />
+
     return (
         <AppcoverContainer>
             <Navbar></Navbar>

--- a/frontend/src/pages/auth/auth.styles.ts
+++ b/frontend/src/pages/auth/auth.styles.ts
@@ -71,7 +71,7 @@ export const AuthInput = styled.input`
     }
 `
 
-export const AuthButton = styled.button`
+export const AuthButton = styled.button<{ $submitting?: boolean }>`
     width: 100%;
     padding: 0.6rem 1.5rem;
     font-size: 1.4rem;
@@ -80,9 +80,9 @@ export const AuthButton = styled.button`
     transition: 0.3s ease-in-out;
     cursor: pointer;
 
-    background-color: #1C1A1B;
+    background-color: ${props => props.$submitting ? '#FF0000' : '#1C1A1B'};
     border-radius: 0.5rem;
-    box-shadow: inset 0 0 15px rgba(100, 100, 100, 0.8);
+    box-shadow: ${props => props.$submitting ? 'inset 0 0 15px rgba(255, 255, 255, 0.5)' : 'inset 0 0 15px rgba(100, 100, 100, 0.8)'};
 
     &:hover {
         box-shadow: inset 0 0 15px rgba(255, 255, 255, 1);

--- a/frontend/src/pages/dashboard/dashboard.tsx
+++ b/frontend/src/pages/dashboard/dashboard.tsx
@@ -1,10 +1,6 @@
 import { DashboardContainer, DashboardContent, DashboardFront, DashboardSelector, DashboardThread, DashboardThreadL, DashboardThreadR } from "./dashboard.styles"
 import dash_qa from '../../assets/dashboard/qa.png'
 import Selectorcard from "../../components/selectorcard/selectorcard"
-import { useGlobalContext } from "../../contexts/global.context"
-import { useNavigate } from "react-router-dom"
-import Loading from "../../components/loading/loading"
-import { useEffect } from "react"
 
 const dashboardItems = [
     {
@@ -31,19 +27,6 @@ const dashboardItems = [
 
 
 export default function Dashboard() {
-
-    const { isLoggedIn, isLoading, handleSignOut } = useGlobalContext()
-    const navigate = useNavigate()
-
-    useEffect(() => {
-        if (!isLoggedIn && !isLoading) {
-            handleSignOut!()
-            navigate('/sign-in')
-        }
-    }, [isLoggedIn, isLoading])
-    
-
-    if (isLoading) return <Loading />
 
     return (
         <DashboardContainer>


### PR DESCRIPTION
### Fixes/Implements #11 

## Description

- `handleLogIn` function's documentation was incorrect, is patched.
- Switch the logged in check logic to the <AppCover /> element to avoid glitches in the interface of dashboard.
- We needed a `useEffect` to pull away the user from the sign-in/sign-up pages if they're already logged in, and is implemented
- The `Sign Up` and `Sign In` buttons are blocked when there's an ongoing sign-in, and there is an indicator toast of it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested
