### PR TITLE
feat(faq): creation of `QEditor` page

### DIFF
--- a/backend/core/schema/faq.py
+++ b/backend/core/schema/faq.py
@@ -31,3 +31,16 @@ class FAQDetails(BaseModel):
     question: str = Field(example = "How to return a product?")
     answer: str = Field(example = "You can return a product by visiting the nearest store")
     order: int = Field(example = 1, min = 1)
+
+class FAQUpdate(BaseModel):
+    """
+    FAQUpdate: A class to represent the details of a FAQ update
+
+    Attributes:
+    - faq_id (str): the FAQ ID
+    - question (str): the question
+    - answer (str): the answer 
+    """
+    faq_id: str = Field(example = "1")
+    question: str = Field(example = "How to return a product?")
+    answer: str = Field(example = "You can return a product by visiting the nearest store")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,11 @@
   "dependencies": {
     "@styled-icons/heroicons-solid": "^10.47.0",
     "axios": "^1.6.7",
-    "framer-motion": "^10.16.12",
+    "framer-motion": "^10.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.1",
+    "react-textarea-autosize": "^8.5.3",
     "react-toastify": "^10.0.4",
     "styled-components": "^6.1.1"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { GlobalContext, GlobalContextDefault } from "./contexts/global.context";
 import axios from "axios";
 import { ToastContainer, Zoom, toast } from "react-toastify";
 import 'react-toastify/dist/ReactToastify.css';
+import Editor from "./pages/editor/editor";
 
 const Hero = lazy(() => import("./pages/hero/hero"));
 const FAQ = lazy(() => import("./pages/faq/faq"));
@@ -132,6 +133,7 @@ export default function App() {
               <Route path="/" element={<Hero />} />
               <Route path="/faq" element={<FAQ />} />
               <Route path="/app/dashboard" element={<Appcover children={<Dashboard />} />} />
+              <Route path="/app/editor" element={<Appcover children={<Editor />} />} />
               <Route path="/sign-in" element={<SignIn />} />
               <Route path="/sign-up" element={<SignUp />} />
           </Routes>

--- a/frontend/src/components/appcover/appcover.styles.ts
+++ b/frontend/src/components/appcover/appcover.styles.ts
@@ -1,7 +1,19 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
+
+export const bgSlide = keyframes`
+    0% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: 100% 0;
+    }
+`
 
 export const AppcoverContainer = styled.div`
     background-color: #000000;
+    background-color: #000000;
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23e81f00' fill-opacity='0.16'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+    animation: ${bgSlide} 45s linear infinite;
     width: 100%;
     min-height: 100%;
     display: grid;

--- a/frontend/src/components/appcover/appcover.tsx
+++ b/frontend/src/components/appcover/appcover.tsx
@@ -1,27 +1,46 @@
 import { useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import Navbar from "../navbar/navbar";
 import { AppcoverContainer, AppcoverDisplay } from "./appcover.styles";
 import Loading from "../loading/loading";
 
 import { useGlobalContext } from "../../contexts/global.context";
+import { LoadingContainer } from "../loading/loading.styles";
 
 
 export default function Appcover({ children }: { children: React.ReactNode }) {
 
     const { isLoggedIn, isLoading, handleSignOut } = useGlobalContext()
+
+    const [isDone, setIsDone] = useState<boolean>(false)
     const navigate = useNavigate()
 
     useEffect(() => {
+        /*
+
+        UseEffect Function to check if user is logged in
+
+        @return void
+        */
+
         if (!isLoggedIn && !isLoading) {
             handleSignOut!()
             navigate('/sign-in')
         }
+        if (isLoggedIn && !isLoading) {
+            setTimeout(() => {
+                setIsDone(true)
+            }, 2000)
+        }
     }, [isLoggedIn, isLoading])
     
 
-    if (isLoading || !isLoggedIn) return <Loading />
+    if (isLoading || !isLoggedIn || !isDone) return (
+        <LoadingContainer>
+            <Loading />
+        </LoadingContainer>
+    )
 
     return (
         <AppcoverContainer>

--- a/frontend/src/components/confirmation/confirmation.styles.ts
+++ b/frontend/src/components/confirmation/confirmation.styles.ts
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+export const ConfirmationContainer = styled.div`
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 3rem;
+    background-color: #000000;
+    box-shadow: inset 0 0 20px rgba(100, 100, 100, 0.8);
+    border-radius: 1rem;
+    padding: 2rem;
+    box-sizing: border-box;
+
+    @media only screen and (max-width: 900px) {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr auto;
+    }
+`
+
+export const ConfirmationElement = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 14rem;
+`
+
+export const ConfirmationButtons = styled.div`
+    height: 100%;
+    
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+
+    @media only screen and (max-width: 900px) {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+`

--- a/frontend/src/components/confirmation/confirmation.tsx
+++ b/frontend/src/components/confirmation/confirmation.tsx
@@ -1,0 +1,38 @@
+import { QreateSubtitle } from ".."
+import { FAQCancelIcon, FAQDeleteIcon, FAQDoneIcon, FAQIcon } from "../faqeditentry/faqeditentry.styles"
+import { ConfirmationButtons, ConfirmationContainer, ConfirmationElement } from "./confirmation.styles"
+
+export enum ConfirmationEnum {
+    DELETE,
+    DONE
+}
+
+export interface ConfirmationProps {
+    title: string,
+    message: string,
+    confirmation: ConfirmationEnum,
+    onDone: () => void,
+    onCancel: () => void
+}
+
+
+export default function Confirmation({ title, message, confirmation, onDone, onCancel }: ConfirmationProps){
+    return (
+        <ConfirmationContainer>
+            <ConfirmationElement>
+                <QreateSubtitle left color="white">{title}</QreateSubtitle>
+                <QreateSubtitle left small color="grey">{message}</QreateSubtitle>
+            </ConfirmationElement>
+            <ConfirmationElement>
+                <ConfirmationButtons>
+                    <FAQIcon $color="white" onClick={onCancel}>
+                        <FAQCancelIcon />
+                    </FAQIcon>
+                    <FAQIcon $color="red" onClick={onDone}>
+                        {confirmation === ConfirmationEnum.DELETE ? <FAQDeleteIcon /> : <FAQDoneIcon />}
+                    </FAQIcon>  
+                </ConfirmationButtons>
+            </ConfirmationElement>
+        </ConfirmationContainer>
+    )
+}

--- a/frontend/src/components/faqadd/faqadd.styles.ts
+++ b/frontend/src/components/faqadd/faqadd.styles.ts
@@ -1,0 +1,41 @@
+import TextAreaAutoSize from "react-textarea-autosize";
+import styled from "styled-components";
+
+export const FAQAddContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    background-color: #000000;
+    box-shadow: inset 0 0 20px rgba(100, 100, 100, 0.8);
+    border-radius: 1rem;
+    padding: 2rem;
+    box-sizing: border-box;
+
+    width: 25rem;
+    max-width: 100%;
+`
+
+export const FAQAddHeader = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`
+
+export const FAQAddBody = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+`
+
+export const FAQAddQA = styled(TextAreaAutoSize)`
+    width: 100%;
+    background-color: #1C1A1B;
+    color: #FFFFFF;
+    border: none;
+    padding: 1rem;
+    box-sizing: border-box;
+    border-radius: 0.5rem;
+    font-size: 1em;
+    resize: none;
+`

--- a/frontend/src/components/faqadd/faqadd.tsx
+++ b/frontend/src/components/faqadd/faqadd.tsx
@@ -46,6 +46,7 @@ export default function FAQAdd({ onCancel, onDone }: FAQAddProps ) {
                 <FAQAddQA
                     placeholder="The meaning of life is 42."
                     value={answer}
+                    minRows={3}
                     onChange={(event) => setAnswer(event.target.value)}
                 />
             </FAQAddBody>

--- a/frontend/src/components/faqadd/faqadd.tsx
+++ b/frontend/src/components/faqadd/faqadd.tsx
@@ -17,6 +17,13 @@ export default function FAQAdd({ onCancel, onDone }: FAQAddProps ) {
     const [answer, setAnswer] = useState<string>("")
 
     const handleDone = () => {
+        /*
+        Function to handle Done
+        
+        @return void
+        
+        */
+
         if (question === "" || answer === "") {
             toast.error("Question or Answer cannot be empty!")
             return

--- a/frontend/src/components/faqadd/faqadd.tsx
+++ b/frontend/src/components/faqadd/faqadd.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { QreateSubtitle } from "..";
+import { FAQCancelIcon, FAQDoneIcon, FAQIcon, FAQIcons } from "../faqeditentry/faqeditentry.styles";
+import { FAQAddBody, FAQAddContainer, FAQAddHeader, FAQAddQA } from "./faqadd.styles";
+import { toast } from "react-toastify";
+
+
+export interface FAQAddProps {
+    onCancel: () => void,
+    onDone: (question: string, answer: string) => void
+}
+
+
+export default function FAQAdd({ onCancel, onDone }: FAQAddProps ) {
+
+    const [question, setQuestion] = useState<string>("")
+    const [answer, setAnswer] = useState<string>("")
+
+    const handleDone = () => {
+        if (question === "" || answer === "") {
+            toast.error("Question or Answer cannot be empty!")
+            return
+        }
+        onDone(question, answer)
+    }
+
+    return (
+        <FAQAddContainer>
+            <FAQAddHeader>
+                <QreateSubtitle left color="white">New FAQ</QreateSubtitle>
+                <FAQIcons>
+                    <FAQIcon $color="white" onClick={onCancel}>
+                        <FAQCancelIcon />
+                    </FAQIcon>
+                    <FAQIcon $color="white" onClick={handleDone}>
+                        <FAQDoneIcon />
+                    </FAQIcon>
+                </FAQIcons>
+            </FAQAddHeader>
+            <FAQAddBody>
+                <FAQAddQA
+                    placeholder="What is the meaning of life?"
+                    value={question}
+                    onChange={(event) => setQuestion(event.target.value)}
+                />
+                <FAQAddQA
+                    placeholder="The meaning of life is 42."
+                    value={answer}
+                    onChange={(event) => setAnswer(event.target.value)}
+                />
+            </FAQAddBody>
+        </FAQAddContainer>
+    )
+}

--- a/frontend/src/components/faqeditentry/faqeditentry.styles.ts
+++ b/frontend/src/components/faqeditentry/faqeditentry.styles.ts
@@ -1,0 +1,133 @@
+import { Bars3, Check, Cog, Trash, XMark } from "@styled-icons/heroicons-solid";
+import { Reorder, motion } from "framer-motion";
+import TextareaAutosize from "react-textarea-autosize";
+import styled from "styled-components";
+
+export const FAQEditEntryContainer = styled(Reorder.Item)`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    border-bottom: 0.5px solid #FFFFFF;
+`
+
+export const FAQEditEntryQuestion = styled.div`
+    display: grid;
+    padding: 1rem 0;
+    grid-template-columns: 3rem 1fr auto;
+    width: 100%;
+    min-height: 4rem;
+    cursor: pointer;
+
+    transition: all 0.3s ease-in-out;
+
+    img {
+        width: 3rem;
+        height: 3rem;
+        object-fit: contain;
+        user-select: none;
+        align-self: center;
+        justify-self: end;
+    }
+`
+
+export const FAQEditEntryQE = styled.div`
+    align-self: center;
+`
+
+export const FAQEditQA = styled(TextareaAutosize)`
+    resize: none; 
+    overflow: hidden;
+    width: 100%;
+    background-color: transparent;
+    border: none;
+    color: #FFFFFF;
+    text-align: left;
+    letter-spacing: -0.02em;
+    user-select: none;
+
+    &:focus {
+        outline: none;
+    }
+`
+
+export const FAQEditQuestion = styled(FAQEditQA)`
+    padding-right: 1.5rem;
+    box-sizing: border-box;
+    font-size: 1.2em;
+    font-weight: 600;
+`
+
+export const FAQEditAnswer = styled(FAQEditQA)`
+    padding-left: 2.3rem;
+    box-sizing: border-box;
+    font-size: 1em;
+    font-weight: 400;
+`
+
+export const FAQEditEntryAE = styled.div`
+    padding: 1rem 0.5rem;
+    padding-top: 0;
+`
+
+export const FAQEditEntryAnswer = styled(motion.div)`
+    width: 100%;
+`
+
+export const FAQIcons = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+`
+
+export const FAQIcon = styled.div<{ $transform?: string, $color?: string }>`
+    border: none;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: ${ props => props.$color ? props.$color : "#1C1A1B"};
+    transition: all 0.3s ease-in-out;
+    padding: ${ props => props.$transform === "rotate" ? "0.5rem" : "0.7rem"};
+    cursor: pointer;
+    box-sizing: border-box;
+    border-radius: 50%;
+    cursor: pointer;
+
+    &:hover {
+        transform: ${ props => props.$transform === "rotate" ? "rotate(360deg)" : "none" };
+    }
+`
+
+export const FAQEditIcon = styled(Cog)`
+    color: #FFFFFF;
+    width: 100%;
+    height: 100%;
+`
+
+export const FAQDoneIcon = styled(Check)`
+    stroke-width: 2rem;
+    color: #00B548;
+`
+
+export const FAQCancelIcon = styled(XMark)`
+    stroke-width: 1rem;
+    color: #FF0000;
+`
+
+export const FAQDeleteIcon = styled(Trash)`
+    color: #000000;
+`
+
+export const FAQEditDrag = styled.div`
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    display: flex;
+    align-items: center;
+`
+
+export const FAQEditDragIcon = styled(Bars3)`
+    width: 1.2rem;
+    color: #FFFFFF;
+`

--- a/frontend/src/components/faqeditentry/faqeditentry.tsx
+++ b/frontend/src/components/faqeditentry/faqeditentry.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from "react";
+import { FAQCancelIcon, FAQDeleteIcon, FAQDoneIcon, FAQEditAnswer, FAQEditDrag, FAQEditDragIcon, FAQEditEntryAE, FAQEditEntryAnswer, FAQEditEntryContainer, FAQEditEntryQE, FAQEditEntryQuestion, FAQEditIcon, FAQEditQuestion, FAQIcon, FAQIcons } from "./faqeditentry.styles";
+
+import { AnimatePresence, useDragControls, useMotionValue } from "framer-motion";
+import { FAQEntryInterface } from "../../pages/editor/editor";
+import { toast } from "react-toastify";
+import axios from "axios";
+import Confirmation, { ConfirmationEnum } from "../confirmation/confirmation";
+import PopUp from "../popup/popup";
+
+export interface FAQEditEntryProps {
+    item: FAQEntryInterface,
+    setFAQList: React.Dispatch<React.SetStateAction<FAQEntryInterface[]>>
+}
+
+
+export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
+
+    const [isEditing, setIsEditing] = useState<boolean>(false)
+    const [question, setQuestion] = useState<string>(item.question)
+    const [answer, setAnswer] = useState<string>(item.answer)
+
+    const [isDeleting, setIsDeleting] = useState<boolean>(false)
+
+    const handleClick = () => {
+        setIsEditing(!isEditing)
+    }
+
+    const handleQuestionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setQuestion(event.target.value)
+    }
+
+    const handleAnswerChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setAnswer(event.target.value)
+    }
+
+    const handleCancel = () => {
+        setQuestion(item.question)
+        setAnswer(item.answer)
+        setIsEditing(false)
+    }
+
+    const handleDone = () => {
+        if (question === "" || answer === "") {
+            toast.error("Question and Answer cannot be empty!")
+            return
+        }
+        if (question === item.question && answer === item.answer) {
+            setIsEditing(false)
+            return
+        }
+        axios.put(import.meta.env.VITE_BASE_API + '/faq/update-faq', {
+            faq_id: item.faq_id,
+            question: question,
+            answer: answer,
+            order: item.order,
+        })
+        .then(() => {
+            toast.success("FAQ Updated Successfully!")
+            setFAQList(prev => {
+                return prev.map(entry => {
+                    if (entry.faq_id === item.faq_id) {
+                        return {
+                            ...entry,
+                            question: question,
+                            answer: answer
+                        }
+                    }
+                    return entry
+                })
+            })
+            setIsEditing(false)
+        })
+        .catch(() => {
+            toast.error("An error occurred while updating FAQ!")
+        })
+    }
+
+    const handleDelete = () => {
+        axios.delete(import.meta.env.VITE_BASE_API + '/faq/delete-faq', {
+            params: {
+                faq_id: item.faq_id
+            }
+        })
+        .then(() => {
+            setIsDeleting(false)
+            toast.success("FAQ Deleted Successfully!")
+            setFAQList(prev => {
+                return prev.filter(entry => entry.faq_id !== item.faq_id)
+            })
+        })
+        .catch(() => {
+            toast.error("An error occurred while deleting FAQ!")
+        })
+    }
+
+    const y = useMotionValue(0)
+    const dragControls = useDragControls()
+
+
+    return (
+        <FAQEditEntryContainer
+            value={item}
+            id={item.faq_id}
+            style={{ y, touchAction: 'pan-x' }}
+            dragListener={false}
+            dragControls={dragControls}
+        >
+            <FAQEditEntryQuestion>
+                <FAQEditDrag 
+                    onPointerDown={(event) => {
+                        event.preventDefault()
+                        handleCancel()
+                        dragControls.start(event)
+                    }}
+                >
+                    <FAQEditDragIcon />
+                </FAQEditDrag>
+                <FAQEditEntryQE>
+                    <FAQEditQuestion
+                        value={question}
+                        onChange={handleQuestionChange}
+                        disabled={!isEditing}
+                        placeholder="Did you just clear the entire question?"
+                    />
+                </FAQEditEntryQE>
+                <FAQIcons>  
+                {
+                    !isEditing ? 
+                    <FAQIcon $transform="rotate" onClick={handleClick} >
+                        <FAQEditIcon />
+                    </FAQIcon>
+                    :
+                    <>
+                        <FAQIcon $color="red" onClick={() => setIsDeleting(true)}>
+                            <FAQDeleteIcon />
+                        </FAQIcon>
+                        <FAQIcon $color="white" onClick={handleCancel}>
+                            <FAQCancelIcon />
+                        </FAQIcon>
+                        <FAQIcon $color="white" onClick={handleDone}>
+                            <FAQDoneIcon />
+                        </FAQIcon>
+                    </>
+                }
+                </FAQIcons>
+            </FAQEditEntryQuestion>
+            <AnimatePresence>
+                {
+                    isEditing &&
+                    <FAQEditEntryAnswer
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: 'auto', opacity: 1 }}
+                        exit={{ height: 0, opacity: 0, padding: 0 }}
+                        transition={{ duration: 0.2 }}
+                    >
+                        <FAQEditEntryAE>
+                            <FAQEditAnswer
+                                value={answer}
+                                onChange={handleAnswerChange}
+                                disabled={!isEditing}
+                                placeholder="There is no question without an answer. Let your creativity flow!"
+                            />
+                        </FAQEditEntryAE>
+                    </FAQEditEntryAnswer>
+                }
+            </AnimatePresence>
+            <PopUp 
+                condition={isDeleting}
+                onCancel={() => setIsDeleting(false)}
+            >
+                <Confirmation 
+                    title="Delete FAQ"
+                    message="Are you sure you want to delete this FAQ?"
+                    confirmation={ConfirmationEnum.DELETE}
+                    onDone={handleDelete}
+                    onCancel={() => setIsDeleting(false)}
+                />
+            </PopUp>
+        </FAQEditEntryContainer>
+    )
+}

--- a/frontend/src/components/faqeditentry/faqeditentry.tsx
+++ b/frontend/src/components/faqeditentry/faqeditentry.tsx
@@ -23,24 +23,58 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
     const [isDeleting, setIsDeleting] = useState<boolean>(false)
 
     const handleClick = () => {
+        /*
+        Function to handle Clicks for a editing toggle
+
+        @return void
+        */
+
         setIsEditing(!isEditing)
     }
 
     const handleQuestionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        /*
+        Function to handle Question Change
+
+        @param event: React.ChangeEvent<HTMLTextAreaElement>
+
+        @return void
+        */
+
         setQuestion(event.target.value)
     }
 
     const handleAnswerChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        /*
+        Function to handle Answer Change
+
+        @param event: React.ChangeEvent<HTMLTextAreaElement>
+
+        @return void
+        */
+
         setAnswer(event.target.value)
     }
 
     const handleCancel = () => {
+        /*
+        Function to handle Cancel Editing
+
+        @return void
+        */
+
         setQuestion(item.question)
         setAnswer(item.answer)
         setIsEditing(false)
     }
 
     const handleDone = () => {
+        /*
+        Function to handle Done Editing
+
+        @return void
+        */
+
         if (question === "" || answer === "") {
             toast.error("Question and Answer cannot be empty!")
             return
@@ -76,6 +110,12 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
     }
 
     const handleDelete = () => {
+        /*
+        Function to handle Delete FAQ
+
+        @return void
+        */
+
         axios.delete(import.meta.env.VITE_BASE_API + '/faq/delete-faq', {
             params: {
                 faq_id: item.faq_id

--- a/frontend/src/components/faqeditentry/faqeditentry.tsx
+++ b/frontend/src/components/faqeditentry/faqeditentry.tsx
@@ -49,11 +49,10 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
             setIsEditing(false)
             return
         }
-        axios.put(import.meta.env.VITE_BASE_API + '/faq/update-faq', {
+        axios.put(import.meta.env.VITE_BASE_API + '/faq/update-faq-qa', {
             faq_id: item.faq_id,
             question: question,
             answer: answer,
-            order: item.order,
         })
         .then(() => {
             toast.success("FAQ Updated Successfully!")
@@ -105,6 +104,8 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
             style={{ y, touchAction: 'pan-x' }}
             dragListener={false}
             dragControls={dragControls}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
         >
             <FAQEditEntryQuestion>
                 <FAQEditDrag 

--- a/frontend/src/components/loading/loading.styles.ts
+++ b/frontend/src/components/loading/loading.styles.ts
@@ -1,33 +1,20 @@
-import styled, { keyframes } from "styled-components";
-
-export const LoadingShine = keyframes`
-    0% {
-		background-position: -200px;
-	}
-	100% {
-		background-position: 200px;
-	}
-`
+import { motion } from "framer-motion";
+import styled from "styled-components";
+import { bgSlide } from "../appcover/appcover.styles";
 
 export const LoadingContainer = styled.div`
     width: 100%;
-    height: 90vh;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: white;
+	background-color: #000000;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23e81f00' fill-opacity='0.16'%3E%3Cpath d='M0 38.59l2.83-2.83 1.41 1.41L1.41 40H0v-1.41zM0 1.4l2.83 2.83 1.41-1.41L1.41 0H0v1.41zM38.59 40l-2.83-2.83 1.41-1.41L40 38.59V40h-1.41zM40 1.41l-2.83 2.83-1.41-1.41L38.59 0H40v1.41zM20 18.6l2.83-2.83 1.41 1.41L21.41 20l2.83 2.83-1.41 1.41L20 21.41l-2.83 2.83-1.41-1.41L18.59 20l-2.83-2.83 1.41-1.41L20 18.59z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+	animation: ${bgSlide} 45s linear infinite;
 `
 
-export const LoadingContent = styled.p`
-    background: #222 -webkit-gradient(linear, left top, right top, from(#000), to(#000), color-stop(0.1, #000)) 0 0 no-repeat;
-	background-image: -webkit-linear-gradient(-40deg, transparent 0%, transparent 40%, #fff 50%, transparent 60%, transparent 100%);
-	-webkit-background-size: 200px;
-	color: transparent;
-	-webkit-background-clip: text;
-	-webkit-animation-name: ${LoadingShine};
-	-webkit-animation-duration: 1s;
-	-webkit-animation-iteration-count: infinite;
-    font-size: 4em;
-    font-weight: 900;
-    user-select: none;
+export const LoadingContent = styled(motion.div)`
+	width: 3rem;
+	height: 3rem;
+	background-color: white;
 `

--- a/frontend/src/components/loading/loading.tsx
+++ b/frontend/src/components/loading/loading.tsx
@@ -1,9 +1,20 @@
-import { LoadingContainer, LoadingContent } from "./loading.styles";
+import { LoadingContent } from "./loading.styles";
 
 export default function Loading() {
     return (
-        <LoadingContainer>
-            <LoadingContent>Qreate</LoadingContent>
-        </LoadingContainer>
+        <LoadingContent
+            animate={{
+                scale: [1, 1.5, 1.5, 1, 1],
+                rotate: [0, 0, 180, 180, 0],
+                borderRadius: ["0%", "0%", "50%", "50%", "0%"]
+            }}
+            transition={{
+                duration: 2,
+                ease: "easeInOut",
+                times: [0, 0.2, 0.5, 0.8, 1],
+                repeat: Infinity,
+                repeatDelay: 1
+            }}
+        />
     )
 }

--- a/frontend/src/components/popup/popup.styles.ts
+++ b/frontend/src/components/popup/popup.styles.ts
@@ -1,0 +1,22 @@
+import { motion } from "framer-motion";
+import styled from "styled-components";
+
+export const PopUpContainer = styled(motion.div)`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 998;
+    padding: 1rem;
+`
+
+export const PopUpAnimator = styled(motion.div)`
+    height: auto;
+    width: auto;
+    max-width: 95%;
+`

--- a/frontend/src/components/popup/popup.tsx
+++ b/frontend/src/components/popup/popup.tsx
@@ -1,0 +1,34 @@
+import { AnimatePresence } from "framer-motion"
+import { PopUpAnimator, PopUpContainer } from "./popup.styles"
+
+export interface PopUpProps {
+    condition: boolean,
+    onCancel: () => void,
+    children: React.ReactNode
+}
+
+export default function PopUp({ condition, onCancel, children }: PopUpProps) {
+    return (
+        <AnimatePresence>
+            { condition &&
+                <PopUpContainer
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                    onClick={onCancel}
+                >
+                    <PopUpAnimator
+                        initial={{ y: -20, opacity: 0 }}
+                        animate={{ y: 0, opacity: 1 }}
+                        exit={{ y: 50, opacity: 0 }}
+                        transition={{ duration: 0.2 }}
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        {children}
+                    </PopUpAnimator>
+                </PopUpContainer>
+            }
+        </AnimatePresence>
+    )
+}

--- a/frontend/src/pages/editor/editor.styles.ts
+++ b/frontend/src/pages/editor/editor.styles.ts
@@ -82,6 +82,8 @@ export const EditorBox = styled(Reorder.Group)`
     width: 100%;
     display: flex;
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
     gap: 1rem;
     padding: 2rem;
     box-sizing: border-box;

--- a/frontend/src/pages/editor/editor.styles.ts
+++ b/frontend/src/pages/editor/editor.styles.ts
@@ -1,0 +1,96 @@
+import { Plus } from "@styled-icons/heroicons-solid";
+import { Reorder } from "framer-motion";
+import styled from "styled-components";
+
+export const EditorContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    overflow-y: auto;
+    height: 100%;
+`
+
+export const EditorContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 90%;
+    max-width: 50rem;
+`
+
+export const EditorTitle = styled.p`
+    align-items: center;
+    color: #FFFFFF;
+    font-weight: bold;
+    font-size: 2.4rem;
+    user-select: none;
+    margin-bottom: 0.5rem;
+
+    span {
+        font-size: 1.8rem;
+        color: #A0A0A0;
+    }
+
+    @media only screen and (max-width: 900px) {
+        span {
+            font-size: 1.6rem;
+        }
+        font-size: 1.8rem;
+    }
+`
+
+export const EditorSBar = styled.div`
+    display: flex;
+    justify-content: space-between;
+`
+
+export const EditorAdd = styled(Plus)<{ $size: string }>`
+    width: ${ props => props.$size === "large" ? "2.8rem" : "2.2rem"};
+    stroke: #FFFFFF;
+    stroke-width: 0.1rem;
+    transition: all 0.1s ease-in-out;
+    color: #000000;
+    cursor: pointer;
+
+    &:hover {
+        stroke: #FF0000;
+    }
+    @media only screen and (max-width: 900px) {
+        width: ${ props => props.$size === "large" ? "2.2rem" : "2.0rem"};
+    }
+`
+
+export const EditorSTitle = styled.p`
+    align-items: center;
+    color: #FF0000;
+    font-weight: bold;
+    font-size: 1.9rem;
+    user-select: none;
+    margin-bottom: 0.5rem;
+
+    span {
+        color: #FFFFFF;
+    }
+
+    @media only screen and (max-width: 900px) {
+        font-size: 1.6rem;
+    }
+`
+
+export const EditorBox = styled(Reorder.Group)`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem;
+    box-sizing: border-box;
+    background-color: #000000;
+    box-shadow: inset 0 0 20px rgba(100, 100, 100, 0.8);
+    border-radius: 1rem;
+    overflow: hidden;
+
+    @media only screen and (max-width: 900px) {
+        padding: 1rem;
+    }
+`

--- a/frontend/src/pages/editor/editor.tsx
+++ b/frontend/src/pages/editor/editor.tsx
@@ -6,6 +6,7 @@ import FAQAdd from "../../components/faqadd/faqadd";
 import PopUp from "../../components/popup/popup";
 import { toast } from "react-toastify";
 import { FAQIcon } from "../../components/faqeditentry/faqeditentry.styles";
+import Loading from "../../components/loading/loading";
 
 export interface FAQEntryInterface {
     faq_id: string,
@@ -17,17 +18,41 @@ export interface FAQEntryInterface {
 export default function Editor() {
 
     const [FAQList, setFAQList] = useState<FAQEntryInterface[]>([])
+    const [isLoading, setIsLoading] = useState<boolean>(true)
 
     const [isAdding, setIsAdding] = useState<boolean>(false)
 
     useEffect(() => {
+        /*
+
+        UseEffect Function to get FAQ List
+
+        @return void
+        */
+
         axios.get(import.meta.env.VITE_BASE_API + '/faq/get-faqs')
         .then((res) => {
             setFAQList(res.data.data.faq_list.sort((a: FAQEntryInterface, b: FAQEntryInterface) => a.order - b.order))
+
+            setTimeout(() => {
+                setIsLoading(false)
+            }, 500)
+        })
+        .catch(() => {
+            toast.error("An error occurred while getting FAQs!")
         })
     }, [])
 
     const handleReorder = (newOrder: FAQEntryInterface[]) => {
+        /*
+
+        Function to handle reordering of FAQ List
+
+        @param newOrder: FAQEntryInterface[]
+
+        @return void
+        */
+
         const newFAQList = newOrder.map((entry, index) => {
             return {
                 ...entry,
@@ -35,10 +60,26 @@ export default function Editor() {
             }
         })
 
+        axios.put(import.meta.env.VITE_BASE_API + '/faq/update-all-faqs', newFAQList)
+        .then(() => {})
+        .catch(() => {
+            toast.error("An error occurred while updating FAQ List!")
+        })
+
         setFAQList(newFAQList)
     }
 
     const handleAdd = (question: string, answer: string) => {
+        /*
+
+        Function to handle adding of FAQ
+
+        @param question: string
+        @param answer: string
+
+        @return void
+        */
+
         axios.post(import.meta.env.VITE_BASE_API + '/faq/add-faq', {
             question: question,
             answer: answer,
@@ -78,9 +119,14 @@ export default function Editor() {
                     axis="y"
                     onReorder={handleReorder} 
                     values={FAQList}
+                    style={{ height: isLoading ? "20rem" : "auto" }}
+                    animate={{ opacity: 1 }}
+                    initial={{ opacity: 0 }}
                 >
                 {
-                    FAQList.map((entry) => (
+                    isLoading ? (
+                        <Loading />
+                    ) : FAQList.map((entry) => (
                     <FAQEditEntry  
                         key={entry.faq_id}
                         item={entry}

--- a/frontend/src/pages/editor/editor.tsx
+++ b/frontend/src/pages/editor/editor.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { EditorAdd, EditorBox, EditorContainer, EditorContent, EditorSBar, EditorSTitle, EditorTitle } from "./editor.styles";
+import axios from "axios";
+import FAQEditEntry from "../../components/faqeditentry/faqeditentry";
+import FAQAdd from "../../components/faqadd/faqadd";
+import PopUp from "../../components/popup/popup";
+import { toast } from "react-toastify";
+import { FAQIcon } from "../../components/faqeditentry/faqeditentry.styles";
+
+export interface FAQEntryInterface {
+    faq_id: string,
+    question: string,
+    answer: string,
+    order: number
+}
+
+export default function Editor() {
+
+    const [FAQList, setFAQList] = useState<FAQEntryInterface[]>([])
+
+    const [isAdding, setIsAdding] = useState<boolean>(false)
+
+    useEffect(() => {
+        axios.get(import.meta.env.VITE_BASE_API + '/faq/get-faqs')
+        .then((res) => {
+            setFAQList(res.data.data.faq_list.sort((a: FAQEntryInterface, b: FAQEntryInterface) => a.order - b.order))
+        })
+    }, [])
+
+    const handleReorder = (newOrder: FAQEntryInterface[]) => {
+        const newFAQList = newOrder.map((entry, index) => {
+            return {
+                ...entry,
+                order: index + 1
+            }
+        })
+
+        setFAQList(newFAQList)
+    }
+
+    const handleAdd = (question: string, answer: string) => {
+        axios.post(import.meta.env.VITE_BASE_API + '/faq/add-faq', {
+            question: question,
+            answer: answer,
+            order: FAQList.length + 1
+        })
+        .then((res) => {
+            setFAQList(prev => {
+                return [
+                    ...prev,
+                    {
+                        faq_id: res.data.faq.faq_id,
+                        question: question,
+                        answer: answer,
+                        order: prev.length + 1
+                    }
+                ]
+            })
+            toast.success("FAQ Added Successfully!")
+            setIsAdding(false)
+        })
+        .catch(() => {
+            toast.error("An error occurred while adding FAQ!")
+        })
+    }
+
+    return (
+        <EditorContainer>
+            <EditorContent>
+                <EditorTitle>Q<span>Editor</span></EditorTitle>
+                <EditorSBar>
+                    <EditorSTitle>F<span>A</span>Q</EditorSTitle>
+                    <FAQIcon onClick={() => setIsAdding(true)} $transform="rotate">
+                        <EditorAdd $size="large" onClick={() => setIsAdding(true)} />
+                    </FAQIcon>
+                </EditorSBar>
+                <EditorBox
+                    axis="y"
+                    onReorder={handleReorder} 
+                    values={FAQList}
+                >
+                {
+                    FAQList.map((entry) => (
+                    <FAQEditEntry  
+                        key={entry.faq_id}
+                        item={entry}
+                        setFAQList={setFAQList}
+                    />))
+                }
+                </EditorBox>
+            </EditorContent>
+            <PopUp 
+                condition={isAdding}
+                onCancel={() => setIsAdding(false)}
+            >
+                <FAQAdd 
+                    onCancel={() => setIsAdding(false)}
+                    onDone={handleAdd}
+                />
+            </PopUp>
+        </EditorContainer>
+    )
+}

--- a/frontend/src/pages/editor/editor.tsx
+++ b/frontend/src/pages/editor/editor.tsx
@@ -43,22 +43,23 @@ export default function Editor() {
         })
     }, [])
 
-    const handleReorder = (newOrder: FAQEntryInterface[]) => {
+    const handleReorder = (unknownNewOrder: unknown[]) => {
         /*
-
         Function to handle reordering of FAQ List
 
         @param newOrder: FAQEntryInterface[]
 
         @return void
         */
+        
+        const newOrder = unknownNewOrder as FAQEntryInterface[]
 
-        const newFAQList = newOrder.map((entry, index) => {
+        const newFAQList = newOrder.map((entry: FAQEntryInterface, index: number) => {
             return {
                 ...entry,
                 order: index + 1
             }
-        })
+        }) as FAQEntryInterface[]
 
         axios.put(import.meta.env.VITE_BASE_API + '/faq/update-all-faqs', newFAQList)
         .then(() => {})


### PR DESCRIPTION
### Fixes/Implements #13 

## Description

- A page for editing FAQ is created, called the `QEditor`.
- The sub components modified with this PR are `Loading`, and the newer ones added are `Confirmation`, `FAQAdd`, `FAQEntryEdit`, and much more, referred through the changes.
- After a discussion new APIs for FAQ (`./api/faq.py`) were added.
- The added APIs are for updating the `question, answer` alone, and one for altering the entire `FAQList`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Locally Tested
