### PR TITLE
feat(frontend): features overhaul for Qreate

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -42,7 +42,8 @@ async def login_user(brand: BrandLogin, request: Request):
                 "access_token": access_token,
                 "_id": str(brand_find["_id"]),
                 "brand_name": brand_find["brand_name"],
-                "brand_email": brand_find["brand_email"]
+                "brand_email": brand_find["brand_email"],
+                "custom_url": brand_find["custom_url"],
             }
         }
     except Exception as e:
@@ -91,7 +92,8 @@ async def register_user(brand: BrandAuth,request: Request):
                 "access_token": access_token,
                 "_id": str(inserted_user_data["_id"]),
                 "brand_name": inserted_user_data["brand_name"],
-                "brand_email": inserted_user_data["brand_email"]
+                "brand_email": inserted_user_data["brand_email"],
+                "custom_url": ""
             }   
         }
         
@@ -114,7 +116,8 @@ async def authenticate_check(request: Request):
         "data": {
             "_id": str(request.state.brand["_id"]),
             "brand_name": request.state.brand["brand_name"],
-            "brand_email": request.state.brand["brand_email"]
+            "brand_email": request.state.brand["brand_email"],
+            "custom_url": request.state.brand["custom_url"]
         }
     }
 

--- a/backend/api/brand.py
+++ b/backend/api/brand.py
@@ -90,11 +90,13 @@ async def get_public_brand(request: Request, brand_id: str = None, custom_url: s
             return {
                 "message":"Brand fetched successfully!",
                 "data": {
+                    "brand_id": str(brand["_id"]),
                     "brand_name": brand["brand_name"],
                     "brand_desc": brand["brand_desc"],
                     "brand_email": brand["brand_email"],
                     "image_url": brand["image_url"],
-                    "custom_url": brand["custom_url"] 
+                    "custom_url": brand["custom_url"],
+                    "faq": brand["FAQList"],
                 }
             }
         else:

--- a/frontend/src/components/appcover/appcover.styles.ts
+++ b/frontend/src/components/appcover/appcover.styles.ts
@@ -11,16 +11,16 @@ export const bgSlide = keyframes`
 
 export const AppcoverContainer = styled.div`
     background-color: #000000;
-    background-color: #000000;
     background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23e81f00' fill-opacity='0.16'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
     animation: ${bgSlide} 45s linear infinite;
     width: 100%;
     min-height: 100%;
+    max-height: 100vh;
     display: grid;
     grid-template-rows: auto 1fr;
 `
 
 export const AppcoverDisplay = styled.div`
     height: 100%;
-    scroll-behavior: auto;
+    overflow: scroll;
 `

--- a/frontend/src/components/confirmation/confirmation.tsx
+++ b/frontend/src/components/confirmation/confirmation.tsx
@@ -1,5 +1,5 @@
-import { QreateSubtitle } from ".."
-import { FAQCancelIcon, FAQDeleteIcon, FAQDoneIcon, FAQIcon } from "../faqeditentry/faqeditentry.styles"
+import { CancelIcon, DeleteIcon, DoneIcon, QreateSubtitle } from ".."
+import { FAQIcon } from "../faqeditentry/faqeditentry.styles"
 import { ConfirmationButtons, ConfirmationContainer, ConfirmationElement } from "./confirmation.styles"
 
 export enum ConfirmationEnum {
@@ -26,10 +26,10 @@ export default function Confirmation({ title, message, confirmation, onDone, onC
             <ConfirmationElement>
                 <ConfirmationButtons>
                     <FAQIcon $color="white" onClick={onCancel}>
-                        <FAQCancelIcon />
+                        <CancelIcon />
                     </FAQIcon>
                     <FAQIcon $color="red" onClick={onDone}>
-                        {confirmation === ConfirmationEnum.DELETE ? <FAQDeleteIcon /> : <FAQDoneIcon />}
+                        {confirmation === ConfirmationEnum.DELETE ? <DeleteIcon /> : <DoneIcon />}
                     </FAQIcon>  
                 </ConfirmationButtons>
             </ConfirmationElement>

--- a/frontend/src/components/faqadd/faqadd.tsx
+++ b/frontend/src/components/faqadd/faqadd.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { QreateSubtitle } from "..";
-import { FAQCancelIcon, FAQDoneIcon, FAQIcon, FAQIcons } from "../faqeditentry/faqeditentry.styles";
+import { CancelIcon, DoneIcon, QreateSubtitle } from "..";
+import { FAQIcon, FAQIcons } from "../faqeditentry/faqeditentry.styles";
 import { FAQAddBody, FAQAddContainer, FAQAddHeader, FAQAddQA } from "./faqadd.styles";
 import { toast } from "react-toastify";
 
@@ -37,10 +37,10 @@ export default function FAQAdd({ onCancel, onDone }: FAQAddProps ) {
                 <QreateSubtitle left color="white">New FAQ</QreateSubtitle>
                 <FAQIcons>
                     <FAQIcon $color="white" onClick={onCancel}>
-                        <FAQCancelIcon />
+                        <CancelIcon />
                     </FAQIcon>
                     <FAQIcon $color="white" onClick={handleDone}>
-                        <FAQDoneIcon />
+                        <DoneIcon />
                     </FAQIcon>
                 </FAQIcons>
             </FAQAddHeader>

--- a/frontend/src/components/faqeditentry/faqeditentry.styles.ts
+++ b/frontend/src/components/faqeditentry/faqeditentry.styles.ts
@@ -1,4 +1,3 @@
-import { Bars3, Check, Cog, Trash, XMark } from "@styled-icons/heroicons-solid";
 import { Reorder, motion } from "framer-motion";
 import TextareaAutosize from "react-textarea-autosize";
 import styled from "styled-components";
@@ -99,35 +98,10 @@ export const FAQIcon = styled.div<{ $transform?: string, $color?: string }>`
     }
 `
 
-export const FAQEditIcon = styled(Cog)`
-    color: #FFFFFF;
-    width: 100%;
-    height: 100%;
-`
-
-export const FAQDoneIcon = styled(Check)`
-    stroke-width: 2rem;
-    color: #00B548;
-`
-
-export const FAQCancelIcon = styled(XMark)`
-    stroke-width: 1rem;
-    color: #FF0000;
-`
-
-export const FAQDeleteIcon = styled(Trash)`
-    color: #000000;
-`
-
 export const FAQEditDrag = styled.div`
     width: 100%;
     height: 100%;
     cursor: grab;
     display: flex;
     align-items: center;
-`
-
-export const FAQEditDragIcon = styled(Bars3)`
-    width: 1.2rem;
-    color: #FFFFFF;
 `

--- a/frontend/src/components/faqeditentry/faqeditentry.tsx
+++ b/frontend/src/components/faqeditentry/faqeditentry.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FAQCancelIcon, FAQDeleteIcon, FAQDoneIcon, FAQEditAnswer, FAQEditDrag, FAQEditDragIcon, FAQEditEntryAE, FAQEditEntryAnswer, FAQEditEntryContainer, FAQEditEntryQE, FAQEditEntryQuestion, FAQEditIcon, FAQEditQuestion, FAQIcon, FAQIcons } from "./faqeditentry.styles";
+import { FAQEditAnswer, FAQEditDrag, FAQEditEntryAE, FAQEditEntryAnswer, FAQEditEntryContainer, FAQEditEntryQE, FAQEditEntryQuestion, FAQEditQuestion, FAQIcon, FAQIcons } from "./faqeditentry.styles";
 
 import { AnimatePresence, useDragControls, useMotionValue } from "framer-motion";
 import { FAQEntryInterface } from "../../pages/editor/editor";
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import axios from "axios";
 import Confirmation, { ConfirmationEnum } from "../confirmation/confirmation";
 import PopUp from "../popup/popup";
+import { CancelIcon, DeleteIcon, DoneIcon, EditDragIcon, EditIcon } from "..";
 
 export interface FAQEditEntryProps {
     item: FAQEntryInterface,
@@ -155,7 +156,7 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
                         dragControls.start(event)
                     }}
                 >
-                    <FAQEditDragIcon />
+                    <EditDragIcon />
                 </FAQEditDrag>
                 <FAQEditEntryQE>
                     <FAQEditQuestion
@@ -169,18 +170,18 @@ export default function FAQEditEntry({ item, setFAQList }: FAQEditEntryProps ) {
                 {
                     !isEditing ? 
                     <FAQIcon $transform="rotate" onClick={handleClick} >
-                        <FAQEditIcon />
+                        <EditIcon />
                     </FAQIcon>
                     :
                     <>
                         <FAQIcon $color="red" onClick={() => setIsDeleting(true)}>
-                            <FAQDeleteIcon />
+                            <DeleteIcon />
                         </FAQIcon>
                         <FAQIcon $color="white" onClick={handleCancel}>
-                            <FAQCancelIcon />
+                            <CancelIcon />
                         </FAQIcon>
                         <FAQIcon $color="white" onClick={handleDone}>
-                            <FAQDoneIcon />
+                            <DoneIcon />
                         </FAQIcon>
                     </>
                 }

--- a/frontend/src/components/faqentry/faqentry.tsx
+++ b/frontend/src/components/faqentry/faqentry.tsx
@@ -8,6 +8,7 @@ import answer_svg from '../../assets/faq/answer.svg';
 import { AnimatePresence } from "framer-motion";
 
 export interface FAQEntryProps {
+    faq_id: string,
     question: string,
     answer: string
 }

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
+import { Bars3, Camera, Check, Cog, Trash, XMark } from '@styled-icons/heroicons-solid'
 import styled from 'styled-components'
 
 export interface TextProps {
@@ -54,4 +55,99 @@ export const QreateButton = styled.button<{ primary?: boolean, secondary?: boole
         color: ${props => props.primary ? 'black' : props.secondary ? 'white' : 'white'};
         border: ${props => props.primary ? '0.2rem solid black' : props.secondary ? '0.2rem solid white' : '0.2rem solid white'};
     }
+`
+
+export const AppContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 90%;
+    max-width: 50rem;
+`
+
+export const AppTitle = styled.p`
+    align-items: center;
+    color: #FFFFFF;
+    font-weight: bold;
+    font-size: 2.4rem;
+    user-select: none;
+    margin-bottom: 0.5rem;
+
+    span {
+        font-size: 1.8rem;
+        color: #A0A0A0;
+    }
+
+    @media only screen and (max-width: 900px) {
+        span {
+            font-size: 1.6rem;
+        }
+        font-size: 1.8rem;
+    }
+`
+
+export const AppDesc = styled.p`
+    color: #FFFFFF;
+    font-size: 1.1em;
+    user-select: none;
+    margin-bottom: 0.5rem;
+
+    span {
+        color: #FF0000;
+    }
+
+    @media only screen and (max-width: 900px) {
+        font-size: 1rem;
+    }
+`
+
+export const AppSBar = styled.div`
+    display: flex;
+    justify-content: space-between;
+`
+
+export const AppSTitle = styled.p`
+    align-items: center;
+    color: #FF0000;
+    font-weight: bold;
+    font-size: 1.9rem;
+    user-select: none;
+    margin-bottom: 0.5rem;
+
+    span {
+        color: #FFFFFF;
+    }
+
+    @media only screen and (max-width: 900px) {
+        font-size: 1.6rem;
+    }
+`
+
+export const EditIcon = styled(Cog)`
+    color: #FFFFFF;
+    width: 100%;
+    height: 100%;
+`
+
+export const DoneIcon = styled(Check)`
+    stroke-width: 2rem;
+    color: #00B548;
+`
+
+export const CancelIcon = styled(XMark)`
+    stroke-width: 1rem;
+    color: #FF0000;
+`
+
+export const DeleteIcon = styled(Trash)`
+    color: #000000;
+`
+
+export const EditDragIcon = styled(Bars3)`
+    width: 1.2rem;
+    color: #FFFFFF;
+`
+
+export const CameraIcon = styled(Camera)`
+    color: #A0A0A0;
 `

--- a/frontend/src/components/selectorcard/selectorcard.tsx
+++ b/frontend/src/components/selectorcard/selectorcard.tsx
@@ -1,19 +1,29 @@
 import { useNavigate } from "react-router-dom"
 import { SelectorcardContainer, SelectorcardTitle, SelectorcardDescription } from "./selectorcard.styles"
+import { toast } from "react-toastify"
 
 export interface SelectorcardProps {
     title: string,
     description: string,
     link: string,
+    disabled?: boolean
 }
 
-export default function Selectorcard({ title, description, link }: SelectorcardProps) {
+export default function Selectorcard({ title, description, link, disabled }: SelectorcardProps) {
     
     const navigate = useNavigate()
+
+    const handleNavigate = () => {
+        if (disabled) {
+            toast.info("Feature Coming Soon!")
+            return
+        }
+        navigate(link)
+    }
     
     return (
         <SelectorcardContainer
-            onClick={() => navigate(link)}
+            onClick={handleNavigate}
         >
             <SelectorcardTitle>Q<span>{title}</span></SelectorcardTitle>
             <SelectorcardDescription>{description}</SelectorcardDescription>

--- a/frontend/src/contexts/global.context.ts
+++ b/frontend/src/contexts/global.context.ts
@@ -3,19 +3,25 @@ import { Dispatch, SetStateAction, createContext, useContext } from "react";
 export interface GlobalContextInterface {
     brandName: string,
     brandEmail: string,
+    brandID: string,
+    customURL: string,
     isLoading: boolean,
     isLoggedIn: boolean,
     setBrandName?: Dispatch<SetStateAction<string>>,
     setBrandEmail?: Dispatch<SetStateAction<string>>,
+    setBrandID?: Dispatch<SetStateAction<string>>,
+    setCustomURL?: Dispatch<SetStateAction<string>>,
     setIsLoading?: Dispatch<SetStateAction<boolean>>,
     setIsLoggedIn?: Dispatch<SetStateAction<boolean>> 
-    handleLogIn?: (token: string, brand_name: string, brand_email: string) => void,
+    handleLogIn?: (token: string, brand: GlobalContextInterface) => void,
     handleSignOut?: () => void
 }
 
 export const GlobalContextDefault: GlobalContextInterface = {
     brandName: '',
     brandEmail: '',
+    brandID: '',
+    customURL: '',
     isLoading: true,
     isLoggedIn: false
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,4 +10,5 @@
 html, body, #root {
     height: 100%;
     width: 100%;
+    background-color: black;
 }

--- a/frontend/src/pages/auth/sign-in.tsx
+++ b/frontend/src/pages/auth/sign-in.tsx
@@ -88,7 +88,15 @@ export default function SignIn() {
         axios.post(import.meta.env.VITE_BASE_API + "/authenticate/login", authForm)
         .then((res) => {
             const data = res.data
-            handleLogIn!(data.data.access_token, data.data.brand_name, data.data.brand_email)
+            const brand = data.data
+            handleLogIn!(data.data.access_token, {
+                brandName: brand.brand_name,
+                brandEmail: brand.brand_email,
+                brandID: brand._id,
+                customURL: brand.custom_url,
+                isLoading: false,
+                isLoggedIn: true
+            })
             toast.update(toastID, {
                 render: data.message,
                 isLoading: false,

--- a/frontend/src/pages/auth/sign-up.tsx
+++ b/frontend/src/pages/auth/sign-up.tsx
@@ -96,7 +96,15 @@ export default function SignUp() {
         axios.post(import.meta.env.VITE_BASE_API + "/authenticate/register", authForm)
         .then((res) => {
             const data = res.data
-            handleLogIn!(data.data.access_token, data.data.brand_name, data.data.brand_email)
+            const brand = data.data
+            handleLogIn!(data.data.access_token, {
+                brandName: brand.brand_name,
+                brandEmail: brand.brand_email,
+                brandID: brand._id,
+                customURL: brand.custom_url,
+                isLoading: false,
+                isLoggedIn: true
+            })
             toast.update(toastID, {
                 render: data.message,
                 isLoading: false,

--- a/frontend/src/pages/brand/brand.styles.ts
+++ b/frontend/src/pages/brand/brand.styles.ts
@@ -1,0 +1,196 @@
+import { motion } from "framer-motion";
+import styled from "styled-components";
+
+export const BrandContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    overflow-y: auto;
+    padding-bottom: 5rem;
+    box-sizing: border-box;
+    height: 100%;
+    gap: 2rem;
+`
+
+export const BrandContent = styled.div`
+    box-sizing: border-box;
+    background-color: #000000;
+    box-shadow: inset 0 0 20px rgba(100, 100, 100, 0.8);
+    border-radius: 1rem;
+    overflow: hidden;
+    min-height: 20rem;
+    width: 100%;
+    gap: 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`
+
+export const BrandForm = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 3rem 4rem;
+    gap: 3rem;
+
+    @media only screen and (max-width: 600px) {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+    }
+`
+
+export const BrandLogoEditor = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    gap: 1rem;
+    position: relative;
+`
+
+export const BrandLogoInput = styled.input`
+    display: none;
+`
+
+export const BrandLogoPreview = styled.label`
+    width: 100%;
+    max-width: 15rem;
+    aspect-ratio: 1;
+    cursor: pointer;
+    position: relative;
+`
+
+export const BrandLogoImage = styled.img`
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.5rem;
+    background-color: #FFFFFF;
+    overflow: hidden;
+    cursor: pointer;
+    object-fit: cover;
+`
+
+export const BrandLogoEdit = styled(motion.div)`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+`
+
+
+export const BrandLogoOptions = styled.div`
+    display: flex;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 15rem;
+`
+
+export const BrandLogoBtn = styled.div<{ color?:string, disabled?:boolean }>`
+    border-radius: 0.5rem;
+    cursor: pointer;
+    width: 100%;
+    height: 2.2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    box-sizing: border-box;
+    background-color: ${ props => props.color ? props.color : "#FFFFFF" };
+    color: #FFFFFF;
+    font-weight: bold;
+    transition: all 0.2s ease-in-out;
+    box-shadow: ${props => props.disabled ? 'inset 0 0 20px rgba(255, 255, 255, 0.5)' : 'inset 0 0 20px rgba(100, 100, 100, 0.8)'};
+    user-select: none;
+
+    &:hover {
+        background-color: ${ props => props.color ? "#FFFFFF" : "#000000" };
+        color: #000000;
+    }
+`
+
+export const BrandBoxTitle = styled.p`
+    color: #FFFFFF;
+    font-size: 1.2em;
+    font-weight: bold;
+    user-select: none;
+`
+
+export const BrandBoxDesc = styled.p`
+    color: #A0A0A0;
+    font-size: 1em;
+    user-select: none;
+`
+
+export const BrandDetailsEditor = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+    height: 100%;
+`
+
+
+export const BrandLabel = styled.p`
+    font-size: 1rem;
+    color: #FFFFFF;
+    user-select: none;
+`
+
+export const BrandInput = styled.input`
+    width: 100%;
+    padding: 0.6rem 1rem;
+    font-size: 1em;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #1A1A1A;
+    color: #FFFFFF;
+    transition: 0.3s ease;
+    user-select: none;
+    cursor: pointer;
+
+    &:focus {
+        outline: none;
+        background-color: #2A2A2A;
+    }
+`
+
+export const BrandTextArea = styled.textarea`
+    width: 100%;
+    height: 100%;
+    padding: 0.6rem 1rem;
+    font-size: 1em;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #1A1A1A;
+    color: #FFFFFF;
+    transition: 0.3s ease;
+    user-select: none;
+    cursor: pointer;
+    resize: none;
+
+    &:focus {
+        outline: none;
+        background-color: #2A2A2A;
+    }
+`
+
+export const BrandDetailsOptions = styled.div`
+    max-width: 100%;
+    width: 20rem;
+    display: flex;
+    gap: 1rem;
+    align-self: flex-end;
+`

--- a/frontend/src/pages/brand/brand.tsx
+++ b/frontend/src/pages/brand/brand.tsx
@@ -1,0 +1,300 @@
+import { useState, createRef, useEffect } from "react";
+import { AppContent, AppDesc, AppSBar, AppSTitle, AppTitle, CameraIcon, DeleteIcon, DoneIcon } from "../../components";
+import { useGlobalContext } from "../../contexts/global.context";
+import { BrandBoxDesc, BrandBoxTitle, BrandContainer, BrandContent, BrandDetailsEditor, BrandDetailsOptions, BrandForm, BrandInput, BrandLabel, BrandLogoBtn, BrandLogoEdit, BrandLogoEditor, BrandLogoImage, BrandLogoInput, BrandLogoOptions, BrandLogoPreview, BrandTextArea } from "./brand.styles";
+
+import q_logo from "../../assets/faq/logo.png";
+import axios from "axios";
+import { toast } from "react-toastify";
+import Loading from "../../components/loading/loading";
+
+interface BrandDetailsInterface {
+    _id: string,
+    brand_name: string,
+    brand_desc: string,
+    brand_email: string,
+    image_url: boolean,
+    custom_url: string
+}
+
+interface BrandDetailsDataInterface {
+    brand_name: string,
+    brand_desc: string
+}
+  
+export default function Brand() {
+
+    const [isLoading, setIsLoading] = useState<boolean>(true)
+
+    const { brandID } = useGlobalContext()
+
+    const fileInputRef = createRef<HTMLInputElement>()
+
+    const [imageSrc, setImageSrc] = useState<string | undefined>(q_logo)
+    const [imageFile, setImageFile] = useState(null)
+
+    const [brandDetails, setBrandDetails] = useState<BrandDetailsInterface>({
+        _id: "",
+        brand_name: "",
+        brand_desc: "",
+        brand_email: "",
+        image_url: false,
+        custom_url: ""
+    })
+
+    const [brandDetailsData, setBrandDetailsData] = useState<BrandDetailsDataInterface>({
+        brand_name: "",
+        brand_desc: ""
+    })
+
+    useEffect(() => {
+        axios.get(import.meta.env.VITE_BASE_API + '/brand/get-brand')
+        .then(res => {
+            let data = res.data
+            let brand = data.data
+            setBrandDetails(brand)
+            setBrandDetailsData(
+                {
+                    brand_name: brand.brand_name,
+                    brand_desc: brand.brand_desc
+                }
+            )
+            if (brand.image_url) {
+                setImageSrc(import.meta.env.VITE_BASE_API + '/cdn_asset/brand/' + brandID + '.png')
+            }
+        })
+        .catch(() => {
+            toast.error("An error occurred while fetching details!")
+        })
+        .finally(() => {
+            setTimeout(() => {
+                setIsLoading(false)
+            }, 500)
+        })
+    }, [])
+
+    
+    const handleDeleteImage = () => {
+        if (imageSrc === q_logo || !brandDetails.image_url) {
+            toast.info(`Image already removed!`)
+            return
+        }
+        axios.delete(import.meta.env.VITE_BASE_API + '/image/delete-picture')
+        .then(() => {
+            toast.success("Logo Removed Successfully!")
+        })
+        .catch(() => {
+            toast.error("An error occurred while removing logo!")
+        })
+        setImageSrc(q_logo)
+        setImageFile(null)
+        setBrandDetails(
+            {
+                ...brandDetails,
+                image_url: false
+            }
+        )
+        if (fileInputRef.current) {
+            fileInputRef.current.value = ''
+        }
+    }
+
+    const handleUploadImage = () => {
+        if (imageFile === null) {
+            toast.error("Please select an image to upload!")
+            return
+        }
+
+        const formData = new FormData()
+        formData.append('file', imageFile as File)
+        axios.post(import.meta.env.VITE_BASE_API + '/image/update-logo', formData, {
+            headers: {
+                    'Content-Type': 'multipart/form-data'
+            }}
+        )
+        .then(() => {
+            setBrandDetails(
+                {
+                    ...brandDetails,
+                    image_url: true
+                }
+            )
+            toast.success("Logo Updated Successfully!")
+        })
+        .catch(() => {
+            toast.error("An error occurred while updating logo!")
+        })
+    }
+
+    const handleRevertDetails = () => {
+        if (brandDetailsData.brand_name === brandDetails.brand_name && brandDetailsData.brand_desc === brandDetails.brand_desc) {
+            toast.info("No Changes to Revert!")
+            return
+        }
+        setBrandDetailsData(
+            {
+                brand_name: brandDetails.brand_name,
+                brand_desc: brandDetails.brand_desc
+            }
+        )
+        toast.info("Brand Details Reverted Successfully!")
+    }
+
+    const handleSaveDetails = () => {
+        if (brandDetailsData.brand_name.trim() === "" || brandDetailsData.brand_desc.trim() === "") {
+            toast.error("Name or Description is Empty!")
+            return
+        }
+
+        if (brandDetailsData.brand_name === brandDetails.brand_name && brandDetailsData.brand_desc === brandDetails.brand_desc) {
+            toast.info("No Changes to Update!")
+            return
+        }
+        axios.put(import.meta.env.VITE_BASE_API + '/brand/update-profile', {
+            brand_name: brandDetailsData.brand_name,
+            brand_desc: brandDetailsData.brand_desc
+        })
+        .then(() => {
+            setBrandDetails(
+                {
+                    ...brandDetails,
+                    brand_name: brandDetailsData.brand_name,
+                    brand_desc: brandDetailsData.brand_desc
+                }
+            )
+            toast.success("Brand Details Updated Successfully!")
+        })
+        .catch(() => {
+            toast.error("An error occurred while updating brand details!")
+        })
+    }
+
+    return (
+        <BrandContainer>
+            <AppContent>
+                <AppTitle>Q<span>Brand</span></AppTitle>
+                <AppSBar>
+                    <AppSTitle>Pro<span>fi</span>le</AppSTitle>
+                </AppSBar>
+                <AppDesc>
+                    Did you know that setting the <span>right</span> description for a brand can be hard? The importance of branding is reflected, known to Qreate as a fellow brand. Thus, we allow brands to edit their <span>Description</span>, <span>name</span>, and even their <span>Logo</span>. You can then check out the changes <span>reflected</span> on your FAQ page.
+                </AppDesc>
+                <BrandContent>
+                {
+                    isLoading ? (
+                        <Loading />
+                    ) :
+                    <BrandForm>
+                        <BrandLogoEditor>
+                            <BrandBoxTitle>Brand Logo</BrandBoxTitle>
+                            <BrandBoxDesc>
+                                Upload a logo for your brand. This logo will be displayed on your FAQ page.
+                            </BrandBoxDesc>
+                            
+                            <BrandLogoInput
+                                id="brand-logo"
+                                type="file"
+                                ref={fileInputRef}
+                                onChange={(event: any) => {
+                                    setImageSrc(URL.createObjectURL(event.target.files[0]))
+                                    setImageFile(event.target.files[0])
+                                }}
+                                accept="image/*"
+                            />
+                            <BrandLogoPreview
+                                htmlFor="brand-logo"
+                            >
+                                <BrandLogoImage 
+                                    src={imageSrc}
+                                    alt="Brand Logo"
+                                />
+                                <BrandLogoEdit
+                                    initial={{ 
+                                        opacity: 0.2,
+                                        backdropFilter: "blur(0px)",
+                                    }}
+                                    whileHover={{ 
+                                        opacity: 0.8,
+                                        backdropFilter: "blur(3px)",
+                                        borderRadius:"0.5rem",
+                                        transition: {
+                                            duration: 0.2
+                                        }
+                                    }}
+                                >
+                                    <CameraIcon 
+                                        height={"3rem"}
+                                    />
+                                </BrandLogoEdit>
+                            </BrandLogoPreview>
+                            <BrandLogoOptions>
+                                <BrandLogoBtn
+                                    color="red"
+                                    onClick={handleDeleteImage}
+                                >
+                                    <DeleteIcon 
+                                        height={"1.5rem"}
+                                    />
+                                </BrandLogoBtn>
+                                <BrandLogoBtn
+                                    color="#151314"
+                                    onClick={handleUploadImage}
+                                >
+                                    <DoneIcon 
+                                        height={"1.5rem"}
+                                    />
+                                </BrandLogoBtn>
+                            </BrandLogoOptions>
+                        </BrandLogoEditor>
+                        <BrandDetailsEditor>
+                            <BrandBoxTitle>Brand Details</BrandBoxTitle>
+                            <BrandBoxDesc>
+                                Edit the details of your brand. These details will be displayed on your FAQ page.
+                            </BrandBoxDesc>
+                            <BrandLabel>Brand Name</BrandLabel>
+                            <BrandInput 
+                                type="text"
+                                value={brandDetailsData.brand_name}
+                                onChange={(event: any) => {
+                                    setBrandDetailsData(
+                                        {
+                                            ...brandDetailsData,
+                                            brand_name: event.target.value
+                                        }
+                                    )
+                                }}
+                            />
+                            <BrandLabel>Brand Description</BrandLabel>
+                            <BrandTextArea 
+                                value={brandDetailsData.brand_desc}
+                                onChange={(event: any) => {
+                                    setBrandDetailsData(
+                                        {
+                                            ...brandDetailsData,
+                                            brand_desc: event.target.value
+                                        }
+                                    )
+                                }}
+                            />
+                            <BrandDetailsOptions>
+                                <BrandLogoBtn
+                                    color="red"
+                                    onClick={handleRevertDetails}
+                                >
+                                    Revert
+                                </BrandLogoBtn>
+                                <BrandLogoBtn
+                                    color="#151314"
+                                    onClick={handleSaveDetails}
+                                >
+                                    Save
+                                </BrandLogoBtn>
+                            </BrandDetailsOptions>
+                        </BrandDetailsEditor>
+                    </BrandForm>
+                }
+                </BrandContent>
+            </AppContent>
+        </BrandContainer>
+    )
+}

--- a/frontend/src/pages/dashboard/dashboard.styles.ts
+++ b/frontend/src/pages/dashboard/dashboard.styles.ts
@@ -5,8 +5,15 @@ export const DashboardContainer = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    overflow-y: auto;
     width: 100%;
     height: 100%;
+    padding-bottom: 5rem;
+    box-sizing: border-box;
+
+    @media (max-width: 990px) {
+        height: auto;
+    }
 `
 
 export const DashboardContent = styled.div`

--- a/frontend/src/pages/dashboard/dashboard.tsx
+++ b/frontend/src/pages/dashboard/dashboard.tsx
@@ -1,32 +1,37 @@
 import { DashboardContainer, DashboardContent, DashboardFront, DashboardSelector, DashboardThread, DashboardThreadL, DashboardThreadR } from "./dashboard.styles"
 import dash_qa from '../../assets/dashboard/qa.png'
 import Selectorcard from "../../components/selectorcard/selectorcard"
-
-const dashboardItems = [
-    {
-        title: 'Brand',
-        description: 'Qraft your brand and fill details about your brand',
-        link: '/app/brand'
-    },
-    {
-        title: 'Editor',
-        description: 'Edit your Q&As, and preview the FAQsite',
-        link: '/app/editor'
-    },
-    {
-        title: 'lytics',
-        description: 'Analyze your Traffic, insights on Qustomers',
-        link: '/app/analytics'
-    },
-    {
-        title: 'FAQ',
-        description: 'Visit out own preview FAQ site for inspiration.',
-        link: '/faq'
-    }
-]
-
+import { useGlobalContext } from "../../contexts/global.context"
 
 export default function Dashboard() {
+    
+    const { customURL, brandID } = useGlobalContext()
+    
+    let ping_url = customURL ? customURL : 'id/' + brandID
+
+    const dashboardItems = [
+        {
+            title: 'Brand',
+            description: 'Qraft your brand and fill details about your brand',
+            link: '/app/brand'
+        },
+        {
+            title: 'Editor',
+            description: 'Edit your Q&As, and preview the URL of your site',
+            link: '/app/editor'
+        },
+        {
+            title: 'lytics',
+            description: 'Analyze your Traffic, insights on Qustomers',
+            link: '/app/analytics',
+            disabled: true
+        },
+        {
+            title: 'FAQ',
+            description: 'Visit your Q&As in action, in Qreate',
+            link: '/brand/' + ping_url
+        }
+    ]
 
     return (
         <DashboardContainer>
@@ -49,6 +54,7 @@ export default function Dashboard() {
                                 title={item.title}
                                 description={item.description}
                                 link={item.link}
+                                disabled={item.disabled}
                             />
                         )
                     })}

--- a/frontend/src/pages/editor/editor.styles.ts
+++ b/frontend/src/pages/editor/editor.styles.ts
@@ -1,5 +1,5 @@
 import { Plus } from "@styled-icons/heroicons-solid";
-import { Reorder } from "framer-motion";
+import { Reorder, motion } from "framer-motion";
 import styled from "styled-components";
 
 export const EditorContainer = styled.div`
@@ -9,40 +9,9 @@ export const EditorContainer = styled.div`
     width: 100%;
     overflow-y: auto;
     height: 100%;
-`
-
-export const EditorContent = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    width: 90%;
-    max-width: 50rem;
-`
-
-export const EditorTitle = styled.p`
-    align-items: center;
-    color: #FFFFFF;
-    font-weight: bold;
-    font-size: 2.4rem;
-    user-select: none;
-    margin-bottom: 0.5rem;
-
-    span {
-        font-size: 1.8rem;
-        color: #A0A0A0;
-    }
-
-    @media only screen and (max-width: 900px) {
-        span {
-            font-size: 1.6rem;
-        }
-        font-size: 1.8rem;
-    }
-`
-
-export const EditorSBar = styled.div`
-    display: flex;
-    justify-content: space-between;
+    gap: 2rem;
+    padding-bottom: 5rem;
+    box-sizing: border-box;
 `
 
 export const EditorAdd = styled(Plus)<{ $size: string }>`
@@ -58,23 +27,6 @@ export const EditorAdd = styled(Plus)<{ $size: string }>`
     }
     @media only screen and (max-width: 900px) {
         width: ${ props => props.$size === "large" ? "2.2rem" : "2.0rem"};
-    }
-`
-
-export const EditorSTitle = styled.p`
-    align-items: center;
-    color: #FF0000;
-    font-weight: bold;
-    font-size: 1.9rem;
-    user-select: none;
-    margin-bottom: 0.5rem;
-
-    span {
-        color: #FFFFFF;
-    }
-
-    @media only screen and (max-width: 900px) {
-        font-size: 1.6rem;
     }
 `
 
@@ -96,3 +48,94 @@ export const EditorBox = styled(Reorder.Group)`
         padding: 1rem;
     }
 `
+
+export const EditorBoxD = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    gap: 2rem;
+    padding: 3rem 4rem;
+    box-sizing: border-box;
+    background-color: #000000;
+    box-shadow: inset 0 0 20px rgba(100, 100, 100, 0.8);
+    border-radius: 1rem;
+    overflow: hidden;
+
+    @media only screen and (max-width: 900px) {
+        padding: 2rem;
+        flex-direction: column;
+    }
+`
+
+export const EditorBoxDElement = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    width: 100%;
+`
+
+export const EditorBoxDTitle = styled.p`
+    color: #FFFFFF;
+    font-size: 1.2em;
+    font-weight: bold;
+    user-select: none;
+`
+
+export const EditorBoxDDesc = styled.p`
+    color: #A0A0A0;
+    font-size: 1em;
+    user-select: none;
+`
+
+export const EditorBoxDSwitch = styled(motion.div)`
+    width: 4rem;
+    height: 2rem;
+    transition: 0.2s all ease-in-out;
+    border-radius: 2rem;
+    cursor: pointer;
+    display: flex;
+`
+
+export const EditorBoxDSwitchButton = styled(motion.div)`
+    width: 2rem;
+    height: 2rem;
+    background-color: #000000;
+    border: 2px solid #FFFFFF;
+    border-radius: 50%;
+    cursor: pointer;
+`
+
+export const EditorBoxDEditor = styled.div`
+    color: #A0A0A0;
+    user-select: none;
+    display: grid;
+    grid-template-columns: 1fr 6rem;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: #151314;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-sizing: border-box;
+
+    input {
+        background-color: #151314;
+        color: #FFFFFF;
+        border: none;
+        font-size: 1em;
+        outline: none;
+        width: 100%;
+    }
+`
+
+export const EditorBoxDLeft = styled.div`
+    width: max-content;
+    display: flex;
+    flex-direction: column;
+`
+
+export const EditorBoxDRight = styled.div`
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+`
+

--- a/frontend/src/pages/faq/faq.data.ts
+++ b/frontend/src/pages/faq/faq.data.ts
@@ -1,43 +1,42 @@
 import { FAQEntryProps } from "../../components/faqentry/faqentry"
-import qreate_logo from '../../assets/faq/logo.png';
 
-export interface FAQData {
-    brand_details: {
-        name: string,
-        logo: string,
-        description: string
-    },
-    faq_entries: FAQEntryProps[],
-    theme: {
-        background: string
-    }
+export interface FAQDataInterface {
+    brand_id: string,
+    brand_name: string,
+    brand_desc: string,
+    brand_email: string,
+    image_url: boolean,
+    custom_url: string,
+    faq: FAQEntryProps[]
 }
 
-export const QreateFAQData: FAQData = {
-    brand_details: {
-        name: "Qreate",
-        logo: qreate_logo,
-        description: "In a world of questions, be the answer. Elevate user experience with Qreate."
-    },
-    faq_entries: [
+export const QreateFAQData: FAQDataInterface = {
+    brand_id: "1",
+    brand_name: "Qreate",
+    brand_desc: "In a world of questions, be the answer. Elevate user experience with Qreate.",
+    brand_email: "qreate@gmail.com",
+    image_url: false,
+    custom_url: "qreate",
+    faq: [
         {
+            faq_id: "1",
             question: "What is Qreate and how does it work?",
             answer: "Qreate is a user-friendly platform designed to simplify the process of creating FAQ pages for websites and brands. Users can sign in, access their account dashboard, and effortlessly add, edit, or remove FAQ questions and answers. The platform provides customization options for links and allows users to preview their FAQ before publication."
         },
         {
+            faq_id: "2",
             question: "What Customisation options are available in Qreate?",
             answer: "Qreate offers a range of customization options to ensure that your FAQ seamlessly integrates with your website's aesthetics. Users can personalize their FAQ links, making them an extension of their brand. The platform also provides the option to shorten links for enhanced user experience."
         },
         {
+            faq_id: "3",
             question: "Can I preview my FAQ before making it live?",
             answer: "Absolutely! Qreate allows users to preview their FAQ pages before making them live. This feature enables you to visualize how your FAQ will appear on your website, allowing for any necessary adjustments to ensure a flawless user experience."
         },
         {
+            faq_id: "4",
             question: "Is there a limit to the number of FAQ questions and answers I can add?",
             answer: "No, there is no strict limit on the number of FAQ questions and answers you can add. Qreate is designed to accommodate a diverse range of content, allowing you to create comprehensive and informative FAQ pages tailored to your specific needs."
         }
-    ],
-    theme: {
-        background: 'black'
-    }
+    ]
 }

--- a/frontend/src/pages/faq/faq.styles.ts
+++ b/frontend/src/pages/faq/faq.styles.ts
@@ -1,11 +1,17 @@
 import styled from "styled-components";
+import { bgSlide } from "../../components/appcover/appcover.styles";
 
 export const FAQContainer = styled.div<{ background?: string }>`
     width: 100%;
     min-height: 100%;
     background-color: ${props => props.background ? props.background : 'black'};
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23e81f00' fill-opacity='0.16'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+    animation: ${bgSlide} 45s linear infinite;
     font-family: 'Playfair Display', sans-serif;
     padding-bottom: 5rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 `
 
 export const FAQContent = styled.div`
@@ -29,7 +35,7 @@ export const FAQBrandIcon = styled.img`
     width: 8rem;
     background-color: white;
     border-radius: 2rem;
-    object-fit: contain;
+    object-fit: cover;
     height: 8rem;
     max-width: 40%;
 `

--- a/frontend/src/pages/faq/faq.tsx
+++ b/frontend/src/pages/faq/faq.tsx
@@ -1,47 +1,75 @@
 import { FAQBox, FAQBrand, FAQBrandDetails, FAQBrandIcon, FAQContainer, FAQContent, FAQEntries } from "./faq.styles";
 import { QreateText, QreateTitle } from "../../components";
-import { FAQData, QreateFAQData } from "./faq.data";
+import { FAQDataInterface } from "./faq.data";
 import FAQEntry from "../../components/faqentry/faqentry";
 import { useEffect, useState } from "react";
 import Loading from "../../components/loading/loading";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import { toast } from "react-toastify";
+
+import qreate_logo from '../../assets/faq/logo.png';
 
 export default function FAQ() {
 
-    const [FAQData, setFAQData] = useState<FAQData | null>(null)
+    const [FAQData, setFAQData] = useState<FAQDataInterface | null>(null)
     const [loading, setLoading] = useState<boolean>(true)
 
+    const { custom_url, brand_id } = useParams()
+
     useEffect(() => {
+
+        if (!custom_url && !brand_id) {
+            toast.error("Invalid URL")
+            return
+        }
+        let ping_url = custom_url ? custom_url : 'id/' + brand_id
+
+        axios.get(import.meta.env.VITE_BASE_API + '/brand/' + ping_url)
+        .then((res: any) => {
+            const data = res.data
+            const brand = data.data
+            setFAQData(brand)
+            toast.success(data.message)
+        })
+        .catch(() => {
+            toast.error("Something Went Wrong!")
+        })
         
         const timeout = setTimeout(() => {
-            setFAQData(QreateFAQData)
             setLoading(false)
-        }, 2000)
+        }, 1000)
 
         return () => clearTimeout(timeout)
 
     }, [])
 
-    if (loading || FAQData === null) return <Loading />
+    
 
     return (
-        <FAQContainer background={FAQData.theme.background}>
+        <FAQContainer background="black">
+        {
+            loading || FAQData === null ? <Loading />
+            :
             <FAQContent>
                 <FAQBrand>
                     <FAQBrandIcon 
-                        src={FAQData.brand_details.logo}
+                        src={FAQData.image_url ? import.meta.env.VITE_BASE_API + '/cdn_asset/brand/' + FAQData.brand_id + '.png' : qreate_logo}
                         alt="Brand Logo"
                     />
                     <FAQBrandDetails>
-                        <QreateTitle left color="white">{FAQData.brand_details.name}</QreateTitle>
-                        <QreateText left color="white" small>{FAQData.brand_details.description}</QreateText>
+                        <QreateTitle left color="white">{FAQData.brand_name}</QreateTitle>
+                        <QreateText left color="white" small>{FAQData.brand_desc}</QreateText>
                     </FAQBrandDetails>
                 </FAQBrand>
                 <FAQBox>
                     <QreateTitle>FAQ</QreateTitle>
                     <FAQEntries>
                     {
-                        FAQData.faq_entries.map((faq_entry) => (
-                            <FAQEntry 
+                        FAQData.faq.map((faq_entry) => (
+                            <FAQEntry
+                                key={faq_entry.faq_id}
+                                faq_id={faq_entry.faq_id}
                                 question={faq_entry.question}
                                 answer={faq_entry.answer}
                             />
@@ -50,6 +78,7 @@ export default function FAQ() {
                     </FAQEntries>
                 </FAQBox>
             </FAQContent>
+        }
         </FAQContainer>
     )
 }

--- a/frontend/src/pages/hero/hero.styles.ts
+++ b/frontend/src/pages/hero/hero.styles.ts
@@ -1,9 +1,16 @@
 import styled from "styled-components";
+import { bgSlide } from "../../components/appcover/appcover.styles";
 
 export const HeroContainer = styled.div`
     width: 100%;
     min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     font-family: 'Playfair Display', serif;
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23e81f00' fill-opacity='0.16'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+    animation: ${bgSlide} 45s linear infinite;
 `
 
 export const HeroDesc = styled.div`
@@ -16,7 +23,7 @@ export const HeroDesc = styled.div`
     align-items: center;
     justify-content: center;
     text-align: center; 
-    gap: 5rem;
+    gap: 3rem;
 `
 
 export const HeroButtons = styled.div`

--- a/frontend/src/pages/hero/hero.tsx
+++ b/frontend/src/pages/hero/hero.tsx
@@ -6,11 +6,14 @@ import { HeroBG, HeroButtons, HeroContainer, HeroDesc, HeroWorking } from "./her
 import bg_desk from '../../assets/hero/bg-desk.png';
 import HeroCarousel from "../../components/herocarousel/herocarousel";
 import Loading from '../../components/loading/loading';
+import { useNavigate } from 'react-router-dom';
 
 export default function Hero() {
 
     const [isLoading, setIsLoading] = useState<boolean>(true)
     const carouselRef = useRef<HTMLDivElement>(null)
+
+    const navigate = useNavigate()
 
     const handleWorkClick = () => {
         if (carouselRef.current) {
@@ -28,27 +31,31 @@ export default function Hero() {
 
     }, [])
 
-    if (isLoading) return <Loading />
-
     return (
         <HeroContainer>
-            <HeroDesc>
-                <QreateTitle>Qreate</QreateTitle>
-                <QreateText>Unleash the potential of clear communication. Qreate crafts FAQs that resonate with your audience.</QreateText>
-                <HeroButtons>
-                    <QreateButton primary>Coming Soon</QreateButton>
-                    <QreateButton secondary onClick={handleWorkClick}>How It Works?</QreateButton>
-                </HeroButtons>
-            </HeroDesc>
-            <HeroWorking>
-                <HeroBG
-                    src={bg_desk}
-                    alt="background"
-                />
-                <HeroCarousel 
-                    carouselRef={carouselRef}
-                />
-            </HeroWorking>
+        {
+            isLoading ? <Loading />
+            :
+            <>
+                <HeroDesc>
+                    <QreateTitle color='white'>Qreate</QreateTitle>
+                    <QreateText color='white'>Unleash the potential of clear communication. Qreate crafts FAQs that resonate with your audience.</QreateText>
+                    <HeroButtons>
+                        <QreateButton secondary onClick={() => navigate('/sign-up')}>Open Qreate</QreateButton>
+                        <QreateButton primary onClick={handleWorkClick}>How It Works?</QreateButton>
+                    </HeroButtons>
+                </HeroDesc>
+                <HeroWorking>
+                    <HeroBG
+                        src={bg_desk}
+                        alt="background"
+                    />
+                    <HeroCarousel 
+                        carouselRef={carouselRef}
+                    />
+                </HeroWorking>
+            </>
+        }
         </HeroContainer>
     )
 }


### PR DESCRIPTION
### Fixes/Implements #19 

## Description

- The `QEditor` Page, is included with an ability to add Custom-URLs for the brand's Q&A sites. 
- The `QBrand` Page, is built, which can help the brands configure their `brand_logo`, `brand_name` and `brand_description`. 
- The `QBrand` Page now includes a preview for the logo added.
- The `Qlytics` Page is blocked off as a 'Coming Soon` Feature, and is notified with a toast.
- The `QDash` mobile interface is fixed, since it has a bad scroll ability, covering up some of the content beyond scrollable ability.
- The `StyledComponents` code (Components, Icons) are refactored into a general framework as in `index.ts`, allowing for better addition of code, to avoid bloating the entire repository.
- The `FAQPreview` is set with proper data from brands, and will shine, allowing for the final product showcase.
- The toasting for authentication while the user is in the hero page is unconventional, and hence the toast has been removed
- The `Hero` page has changed to a black theme, just like in the actual product.
- The `Coming Soon` flag from the hero page is changed to redirect to the sign-up.
- Some other changes in backend include returning appropriate data from the DB to user.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Locally Tested

